### PR TITLE
from @or-toledano:  Reduce half of similarity muls after encoding (#140)

### DIFF
--- a/clip/model.py
+++ b/clip/model.py
@@ -362,7 +362,7 @@ class CLIP(nn.Module):
         # cosine similarity as logits
         logit_scale = self.logit_scale.exp()
         logits_per_image = logit_scale * image_features @ text_features.t()
-        logits_per_text = logit_scale * text_features @ image_features.t()
+        logits_per_text = logits_per_image.t()
 
         # shape = [global_batch_size, global_batch_size]
         return logits_per_image, logits_per_text


### PR DESCRIPTION
> Reduce half of similarity muls after encoding (#140)
> 
> (cAB)^T = c B^T A^T
> Saves half of the similarity products in the CLIP model.py after the visual/text encoding stages
> 

https://github.com/openai/CLIP/issues/84 for background