### PR TITLE
Can specify download directory

### DIFF
--- a/clip/clip.py
+++ b/clip/clip.py
@@ -40,7 +40,7 @@ _MODELS = {
 }
 
 
-def _download(url: str, root: str = os.path.expanduser("~/.cache/clip")):
+def _download(url: str, root: str):
     os.makedirs(root, exist_ok=True)
     filename = os.path.basename(url)
 
@@ -91,7 +91,7 @@ def available_models() -> List[str]:
     return list(_MODELS.keys())
 
 
-def load(name: str, device: Union[str, torch.device] = None, jit=False):
+def load(name: str, device: Union[str, torch.device] = "cuda" if torch.cuda.is_available() else "cpu", jit: bool = False, download_root: str = None):
     """Load a CLIP model
 
     Parameters
@@ -105,6 +105,9 @@ def load(name: str, device: Union[str, torch.device] = None, jit=False):
     jit : bool
         Whether to load the optimized JIT model or more hackable non-JIT model (default).
 
+    download_root: str
+        path to download the model files; by default, it uses "~/.cache/clip"
+
     Returns
     -------
     model : torch.nn.Module
@@ -116,7 +119,7 @@ def load(name: str, device: Union[str, torch.device] = None, jit=False):
     if device is None:
         device = "cuda" if torch.cuda.is_available() else "cpu"
     if name in _MODELS:
-        model_path = _download(_MODELS[name])
+        model_path = _download(_MODELS[name], download_root or os.path.expanduser("~/.cache/clip"))
     elif os.path.isfile(name):
         model_path = name
     else:


### PR DESCRIPTION
* specify `download_root` to use a location other than `~/.cache/clip`

* also removed unused `Any` type from imports

* from https://github.com/openai/CLIP/commit/22fde59cbe493282dd40a5337f9458003e1c224b